### PR TITLE
Adds macOS, Clang, and ARM coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,32 @@
 language: cpp
 cache: ccache
+
+# We require CMake 3.10 but on Travis ARM xenial is too old (3.5)
+dist: bionic
+
+os:
+  - osx
+  - linux
+osx_image: xcode11.3
+
+arch:
+  - arm64
+  - amd64
+compiler:
+  - clang
+  - gcc
+
+jobs:
+  exclude:
+    - os: osx
+      compiler: gcc
+
 addons:
   apt:
     packages:
       - ninja-build
+  homebrew:
+    packages:
+      - ninja
 script:
   - hack/hack


### PR DESCRIPTION
This expands our build coverage to a matrix of:
Compilers: GCC and Clang
Architecture: amd64 and arm64 (Linux only)
OS: macOS

Couple of notes:
1. We bumped up to Bionic to avoid having an old (3.5) CMake in the ARM
environment (somehow 3.12 was vendored in the amd64 build env even when
distro is set to Xenial)

1. We exclude GCC on macOS because the GCC wrapper for Clang doesn't
really add much value

1. We pin macOS to 10.14 with Xcode 11.3.